### PR TITLE
chore!: rename comment to prefixLines

### DIFF
--- a/templatefuncs.go
+++ b/templatefuncs.go
@@ -26,18 +26,18 @@ var fileModeTypeNames = map[fs.FileMode]string{
 
 func NewFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"comment":          commentTemplateFunc,
 		"contains":         reverseArgs2(strings.Contains),
 		"eqFold":           eqFoldTemplateFunc,
+		"fromJSON":         eachByteSliceErr(fromJSONTemplateFunc),
 		"hasPrefix":        reverseArgs2(strings.HasPrefix),
 		"hasSuffix":        reverseArgs2(strings.HasSuffix),
-		"fromJSON":         eachByteSliceErr(fromJSONTemplateFunc),
 		"hexDecode":        eachStringErr(hex.DecodeString),
 		"hexEncode":        eachByteSlice(hex.EncodeToString),
 		"join":             reverseArgs2(strings.Join),
 		"list":             listTemplateFunc,
 		"lookPath":         eachStringErr(lookPathTemplateFunc),
 		"lstat":            eachString(lstatTemplateFunc),
+		"prefixLines":      prefixLinesTemplateFunc,
 		"quote":            eachString(strconv.Quote),
 		"regexpReplaceAll": regexpReplaceAllTemplateFunc,
 		"stat":             eachString(statTemplateFunc),
@@ -49,7 +49,7 @@ func NewFuncMap() template.FuncMap {
 	}
 }
 
-func commentTemplateFunc(prefix, s string) string {
+func prefixLinesTemplateFunc(prefix, s string) string {
 	type stateType int
 	const (
 		startOfLine stateType = iota

--- a/templatefuncs_test.go
+++ b/templatefuncs_test.go
@@ -53,21 +53,6 @@ func TestFuncMap(t *testing.T) {
 	}{
 		{},
 		{
-			template: `{{ comment "# " "a" }}`,
-			expected: `# a`,
-		},
-		{
-			template: `{{ comment "# " . }}`,
-			data: joinLines(
-				"a",
-				"b",
-			),
-			expected: joinLines(
-				"# a",
-				"# b",
-			),
-		},
-		{
 			template: `{{ "abc" | contains "bc" }}`,
 			expected: "true",
 		},
@@ -108,20 +93,35 @@ func TestFuncMap(t *testing.T) {
 			expected: "true",
 		},
 		{
-			template: `{{ (lstat "testdata/file").type }}`,
-			expected: "file",
-		},
-		{
-			template: `{{ quote "a" }}`,
-			expected: `"a"`,
-		},
-		{
 			template: `{{ list "a" "b" "c" | quote | join "," }}`,
 			expected: `"a","b","c"`,
 		},
 		{
 			template: `{{ (lstat "testdata/file").type }}`,
 			expected: "file",
+		},
+		{
+			template: `{{ (lstat "testdata/file").type }}`,
+			expected: "file",
+		},
+		{
+			template: `{{ prefixLines "# " "a" }}`,
+			expected: `# a`,
+		},
+		{
+			template: `{{ prefixLines "# " . }}`,
+			data: joinLines(
+				"a",
+				"b",
+			),
+			expected: joinLines(
+				"# a",
+				"# b",
+			),
+		},
+		{
+			template: `{{ quote "a" }}`,
+			expected: `"a"`,
 		},
 		{
 			template: `{{ (stat "testdata/file").type }}`,


### PR DESCRIPTION
...and sort functions/tests.

I feel this better communicates what the function does.

That said, prefixing a multiline string with comment syntax is probably the primary use for this function, so I'm happy to close if this is too pedantic.

I was debating whether to extract the prefixing part out to `prefix`, and have `prefixLines` call that for each line in its input, but a function which only prefixes an entire string once is probably just easy enough to do with `printf` etc.